### PR TITLE
feat: 카메라 화면 네비게이션 UX 개선 및 일관된 뒤로가기 버튼 추가

### DIFF
--- a/flutter_app/lib/screens/camera_mode_screen.dart
+++ b/flutter_app/lib/screens/camera_mode_screen.dart
@@ -139,6 +139,18 @@ class _CameraModeScreenState extends State<CameraModeScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black.withOpacity(0.7),
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(
+            Icons.arrow_back_ios_new,
+            color: Colors.white,
+          ),
+          onPressed: () => Navigator.pop(context),
+          tooltip: '뒤로가기',
+        ),
+      ),
       body: SafeArea(
         child: Stack(
           fit: StackFit.expand,
@@ -205,35 +217,22 @@ class _CameraModeScreenState extends State<CameraModeScreen> {
               left: 20,
               right: 20,
               child: Container(
-                padding: const EdgeInsets.symmetric(
-                    vertical: 15.0, horizontal: 10.0),
+                padding: const EdgeInsets.all(16.0),
                 decoration: BoxDecoration(
                     color: Colors.black.withOpacity(0.7),
                     borderRadius: BorderRadius.circular(20)),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceAround,
-                  children: [
-                    Expanded(
-                        child: _buildBottomButton(
-                            icon: Icons.text_fields,
-                            label: '주변 안내',
-                            onPressed: () {})),
-                    Expanded(
-                        child: _buildBottomButton(
-                            icon: Icons.navigation,
-                            label: '길찾기',
-                            onPressed: () {})),
-                    Expanded(
-                        child: _buildBottomButton(
-                            icon: Icons.phone,
-                            label: '보호자호출',
-                            onPressed: () {})),
-                    Expanded(
-                        child: _buildBottomButton(
-                            icon: Icons.settings,
-                            label: '설정',
-                            onPressed: () {})),
-                  ],
+                child: ElevatedButton.icon(
+                  onPressed: () {
+                    // TODO: 음성인식 기능 구현
+                    debugPrint('음성인식 버튼 클릭');
+                  },
+                  icon: const Icon(Icons.mic),
+                  label: const Text('음성 명령'),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.red,
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                  ),
                 ),
               ),
             ),
@@ -243,20 +242,6 @@ class _CameraModeScreenState extends State<CameraModeScreen> {
     );
   }
 
-  Widget _buildBottomButton(
-      {required IconData icon, required String label, required VoidCallback onPressed}) {
-    return GestureDetector(
-      onTap: onPressed,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, color: Colors.white, size: 30),
-          const SizedBox(height: 8),
-          Text(label, style: const TextStyle(color: Colors.white, fontSize: 12)),
-        ],
-      ),
-    );
-  }
 }
 
 class ObjectPainter extends CustomPainter {

--- a/flutter_app/lib/screens/map_screen.dart
+++ b/flutter_app/lib/screens/map_screen.dart
@@ -1068,29 +1068,6 @@ class _MapScreenState extends State<MapScreen> {
             ),
           ),
           if (_showInstructions) _buildInstructionsPanel(),
-          
-          // 하단 버튼 바
-          Positioned(
-            bottom: 90,
-            left: 20,
-            right: 20,
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 15.0, horizontal: 10.0),
-              decoration: BoxDecoration(
-                color: Colors.black.withValues(alpha: 0.7),
-                borderRadius: BorderRadius.circular(20),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                children: [
-                  _buildBottomButton(icon: Icons.text_fields, label: '주변 안내', onPressed: () {}),
-                  _buildBottomButton(icon: Icons.camera, label: '카메라', onPressed: () {}),
-                  _buildBottomButton(icon: Icons.phone, label: '보호자호출', onPressed: () {}),
-                  _buildBottomButton(icon: Icons.settings, label: '설정', onPressed: () {}),
-                ],
-              ),
-            ),
-          ),
         ],
       ),
     );
@@ -1396,23 +1373,6 @@ class _MapScreenState extends State<MapScreen> {
                 );
               },
             ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildBottomButton({required IconData icon, required String label, required VoidCallback onPressed}) {
-    return GestureDetector(
-      onTap: onPressed,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, color: Colors.white, size: 30),
-          const SizedBox(height: 8),
-          Text(
-            label,
-            style: const TextStyle(color: Colors.white, fontSize: 12),
           ),
         ],
       ),

--- a/flutter_app/lib/screens/object_detection_screen.dart
+++ b/flutter_app/lib/screens/object_detection_screen.dart
@@ -147,6 +147,7 @@ class _ObjectDetectionScreenState extends State<ObjectDetectionScreen>
             color: Colors.white,
           ),
           onPressed: () => Navigator.pop(context),
+          tooltip: '뒤로가기',
         ),
         title: const AccessibleTitle(
           '객체 인식',


### PR DESCRIPTION
- 모든 카메라 화면에 일관된 AppBar 뒤로가기 버튼 적용
- map_screen, object_detection_screen, camera_mode_screen 간 네비게이션 패턴 통일
- camera_mode_screen의 다중 하단 버튼을 음성 명령 단일 버튼으로 교체
- map_screen에서 불필요한 하단 네비게이션 바 제거
- 접근성 향상을 위해 모든 뒤로가기 버튼에 툴팁 추가
- 사용자 경험 개선을 위한 통합 UI/UX 패턴 구현

🤖 Generated with [Claude Code](https://claude.ai/code)

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
